### PR TITLE
Remove references to Apache 2.2 and update links to Apache 2.4 docs

### DIFF
--- a/help/using/dispatcher-configuration.md
+++ b/help/using/dispatcher-configuration.md
@@ -1702,7 +1702,7 @@ This will automatically rotate:
 * the dispatcher log file; with a timestamp in the extension (logs/dispatcher.log%Y%m%d).  
 * on a weekly basis (60 x 60 x 24 x 7 = 604800 seconds).
 
-Please see the Apache web server documentation on Log Rotation and Piped Logs; for example [Apache 2.2](https://httpd.apache.org/docs/2.2/logs.html).
+Please see the Apache web server documentation on Log Rotation and Piped Logs; for example [Apache 2.4](https://httpd.apache.org/docs/2.4/logs.html).
 
 >[!NOTE]
 >

--- a/help/using/dispatcher-install.md
+++ b/help/using/dispatcher-install.md
@@ -38,7 +38,6 @@ The following table lists the web server identifier that is used in file names f
 |Web Server|Installation Kit|
 |--- |--- |
 |Apache 2.4| dispatcher-apache**2.4**-&lt;other parameters&gt;|
-|Apache 2.2| dispatcher-apache**2.2**-&lt;other parameters&gt;|
 |Microsoft Internet Information Server 7.5, 8, 8.5|dispatcher-**iis**-&lt;other parameters&gt;|
 |Sun Java Web Server iPlanet | dispatcher-**ns**-&lt;other parameters&gt;|
 
@@ -284,7 +283,7 @@ For Information about how to install an Apache Web Server read the installation 
 >
 >More information can be found in the Apache Web Server installation manual.
 
-Also see the Apache HTTP Server [Security Tips](https://httpd.apache.org/docs/2.2/misc/security_tips.html) and [Security Reports](https://httpd.apache.org/security_report.html).
+Also see the Apache HTTP Server [Security Tips](https://httpd.apache.org/docs/2.4/misc/security_tips.html) and [Security Reports](https://httpd.apache.org/security_report.html).
 
 ### Apache Web Server - Add the Dispatcher Module {#apache-web-server-add-the-dispatcher-module}
 
@@ -412,7 +411,7 @@ The individual configuration parameters:
 |DispatcherLogLevel|Log level for the log file: <br/>0 - Errors <br/>1 - Warnings <br/>2 - Infos <br/>3 - Debug <br/>**Note**: It is recommended to set the log level to 3 during installation and testing, then to 0 when running in a production environment.|
 |DispatcherNoServerHeader|*This parameter is deprecated and no longer has any effect.*<br/><br/> Defines the Server Header to be used: <br/><ul><li>undefined or 0 - the HTTP server header contains the AEM version. </li><li>1 - the Apache server header is used.</li></ul>|
 |DispatcherDeclineRoot|Defines whether to decline requests to the root "/": <br/>**0** - accept requests to / <br/>**1** - requests to / are not handled by the dispatcher; use mod_alias for the correct mapping.|
-|DispatcherUseProcessedURL|Defines whether to use pre-processed URLs for all further processing by Dispatcher: <br/>**0** - use the original URL passed to the web server. <br/>**1** - the dispatcher uses the URL already processed by the handlers that precede the dispatcher (i.e. `mod_rewrite`) instead of the original URL passed to the web server.  For example, either the original or the processed URL is matched with Dispatcher filters. The URL is also used as the basis for the cache file structure.   See the Apache web site documentation for information about mod_rewrite; for example, Apache 2.2. When using mod_rewrite, it is advisable to use the flag 'passthrough|PT' (pass through to next handler) to force the rewrite engine to set the uri field of the internal request_rec structure to the value of the filename field.|
+|DispatcherUseProcessedURL|Defines whether to use pre-processed URLs for all further processing by Dispatcher: <br/>**0** - use the original URL passed to the web server. <br/>**1** - the dispatcher uses the URL already processed by the handlers that precede the dispatcher (i.e. `mod_rewrite`) instead of the original URL passed to the web server.  For example, either the original or the processed URL is matched with Dispatcher filters. The URL is also used as the basis for the cache file structure.   See the Apache web site documentation for information about mod_rewrite; for example, Apache 2.4. When using mod_rewrite, it is advisable to use the flag 'passthrough|PT' (pass through to next handler) to force the rewrite engine to set the uri field of the internal request_rec structure to the value of the filename field.|
 |DispatcherPassError|Defines how to support error codes for ErrorDocument handling: <br/>**0** - Dispatcher spools all error responses to the client. <br/>**1** - Dispatcher does not spool an error response to the client (where the status code is greater or equal than 400), but passes the status code to Apache, which e.g. allows an ErrorDocument directive to process such a status code. <br/>**Code Range** - Specify a range of error codes for which the response is passed to Apache. Other error codes are passed to the client. For example, the following configuration passes responses for error 412 to the client, and all other errors are passed to Apache: DispatcherPassError 400-411,413-417|
 |DispatcherKeepAliveTimeout|Specifies the keep-alive timeout, in seconds. Starting with Dispatcher version 4.2.0 the default keep-alive value is 60. A value of 0 disables keep-alive.|
 |DispatcherNoCanonURL|Setting this parameter to On will pass the raw URL to the backend instead of the canonicalised one and will override the settings of DispatcherUseProcessedURL. The default value is Off. <br/>**Note**: The filter rules in the Dispatcher configuration will always be evaluated against the sanitised URL not the raw URL.|
@@ -431,7 +430,7 @@ The individual configuration parameters:
 >DispatcherNoServerHeader 0`  
 >Which shows the AEM version (for statistical purposes). If you want to disable such information being available in the header you can set: `  
 >ServerTokens Prod`  
->See the [Apache Documentation about ServerTokens Directive (for example, for Apache 2.2)](https://httpd.apache.org/docs/2.2/mod/core.html) for more information.
+>See the [Apache Documentation about ServerTokens Directive (for example, for Apache 2.4)](https://httpd.apache.org/docs/2.4/mod/core.html) for more information.
 
 **SetHandler**
 
@@ -508,7 +507,7 @@ The **ModMimeUsePathInfo** parameter should be set `On` for all Apache configura
 
 `ModMimeUsePathInfo On`
 
-The mod_mime module (see for example, [Apache Module mod_mime](https://httpd.apache.org/docs/2.2/mod/mod_mime.html)) is used to assign content metadata to the content selected for an HTTP response. The default setup means that when mod_mime determines the content type, only the part of the URL that maps to a file or directory will be considered.
+The mod_mime module (see for example, [Apache Module mod_mime](https://httpd.apache.org/docs/2.4/mod/mod_mime.html)) is used to assign content metadata to the content selected for an HTTP response. The default setup means that when mod_mime determines the content type, only the part of the URL that maps to a file or directory will be considered.
 
 When `On`, the `ModMimeUsePathInfo` parameter specifies that `mod_mime` is to determine the content type based on the *complete* URL; this means that virtual resources will have metainformation applied based on their extension.
 

--- a/help/using/dispatcher-ssl.md
+++ b/help/using/dispatcher-ssl.md
@@ -44,7 +44,7 @@ When Dispatcher recieves an HTTPS request, Dispatcher includes the following hea
 * `X-Forwarded-SSL-Keysize`
 * `X-Forwarded-SSL-Session-ID`
 
-A request through Apache-2.2 with `mod_ssl` includes headers that are similar to the following example:
+A request through Apache-2.4 with `mod_ssl` includes headers that are similar to the following example:
 
 ```shell
 X-Forwarded-SSL: on

--- a/help/using/dispatcher.md
+++ b/help/using/dispatcher.md
@@ -264,7 +264,7 @@ There are a numer of ways to control for how long a CDN will cache a resource be
    Configure, how long particular resources are held in the CDN's cache, depending on mime type, extension, request type, etc.  
 
 1. Expiration and cache-control headers  
-   Most CDNs will honor `Expires:` and `Cache-Control:` HTTP Headers if sent by the upstream server. This can be achieved e.g. by using the [mod_expires](https://httpd.apache.org/docs/2.2/mod/mod_expires.html) Apache Module.
+   Most CDNs will honor `Expires:` and `Cache-Control:` HTTP Headers if sent by the upstream server. This can be achieved e.g. by using the [mod_expires](https://httpd.apache.org/docs/2.4/mod/mod_expires.html) Apache Module.
 
 1. Manual invalidation  
    CDNs allow resources to be removed from the cache through web interfaces.

--- a/help/using/security-checklist.md
+++ b/help/using/security-checklist.md
@@ -100,7 +100,7 @@ A denial of service (DoS) attack is an attempt to make a computer resource unava
 
 At the dispatcher level, there are two methods of configuring to prevent DoS attacks: [](https://docs.adobe.com/content/docs/en/dispatcher.html#/filter (Filters))
 
-* Use the mod_rewrite module (for example, [Apache 2.2](https://httpd.apache.org/docs/2.2/mod/mod_rewrite.html)) to perform URL validations (if the URL pattern rules are not too complex).  
+* Use the mod_rewrite module (for example, [Apache 2.4](https://httpd.apache.org/docs/2.4/mod/mod_rewrite.html)) to perform URL validations (if the URL pattern rules are not too complex).
 
 * Prevent the dispatcher from caching URLs with spurious extensions by using [filters](dispatcher-configuration.md#configuring-access-to-conten-tfilter).  
   For example, change the caching rules to limit caching to the expected mime types, such as:


### PR DESCRIPTION
Apache 2.2 is not officially supported anymore so the references should be removed (https://helpx.adobe.com/experience-manager/6-3/sites/deploying/using/technical-requirements.html)