### PR TITLE
Updating "ingnoreUrlParams" for good  practice

### DIFF
--- a/help/using/dispatcher-configuration.md
+++ b/help/using/dispatcher-configuration.md
@@ -1282,29 +1282,32 @@ When a parameter is ignored for a page, the page is cached the first time that t
 
 To specify which parameters are ignored, add glob rules to the `ignoreUrlParams` property:
 
-* To ignore a parameter, create a glob property that allows the parameter.
-* To prevent the page to be cached, create a glob property that denies the parameter.
+* To cache a page despite the request containing an URL parameter create a glob property that allows the parameter (to be ignored).
+* To prevent the page to be cached, create a glob property that denies the parameter (to be ignored).
 
-The following example causes Dispatcher to ignores the `q` parameter, so that request URLs that include the q parameter are cached:
+The following example causes Dispatcher to ignores all parameters, except the `nocache` parameter, so that only request URLs that include the q parameter are never cached by the dispatcher:
 
 ```xml
 /ignoreUrlParams
 {
-    /0001 { /glob "*" /type "deny" }
-    /0002 { /glob "q" /type "allow" }
+    # allow-the-url-parameter-nocache-to-bypass-dispatcher-on-every-request
+    /0001 { /glob "nocache" /type "deny" }
+    # all-other-url-parameters-are-ignored-by-dispatcher-and-requests-are-cached
+    /0002 { /glob "*" /type "allow" }
 }
 ```
 
-Using the example `ignoreUrlParams` value, the following HTTP request causes the page to be cached because the `q` parameter is ignored:
+Using the example `ignoreUrlParams` value, the following HTTP request causes the page to be cached because the `willbecached` parameter is  ignored:
 
 ```xml
-GET /mypage.html?q=5
+GET /mypage.html?willbecached=true
 ```
 
-Using the example `ignoreUrlParams` value, the following HTTP request causes the page to **not** be cached because the `p` parameter is not ignored:
+Using the example `ignoreUrlParams` value, the following HTTP request causes the page to **not** be cached because the `nocache` parameter is not ignored (it is denied to be ingored):
 
 ```xml
-GET /mypage.html?q=5&p=4
+GET /mypage.html?nocache=true
+GET /mypage.html?nocache=true&willbecached=true
 
 ```
 


### PR DESCRIPTION
The previous version of the "ingnoreUrlParams" documentation was "upside down" in relation to good practice. It was "allowing all parameters - except one - to always bypass the Dispatcher and to hit the publisher directly".

Good practice would be to "prevent all parameters to bypass the dispatcher, except the parameters which are absolutely necessary by the application (or for testing)".  The only save way (caching wise) - is not to allow ANY parameters in dispatcher (so every request is being cached) - but that is not always possible by the applications.

This change is to change the documentation to adhere with good-practices.